### PR TITLE
Fix #1045 - Refactor inputExtension method to inputExtensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This repository holds two Quarkus extensions. The one located in the client fold
 
 ## Getting Started
 
-You can learn more in [Quarkus Openapi Generator Documentation](http://docs.quarkiverse.io/quarkus-openapi-generator/dev/index.html).
+You can learn more in [Quarkus OpenAPI Generator Documentation](http://docs.quarkiverse.io/quarkus-openapi-generator/dev/index.html).
 
 > [!TIP]
 > If you want to improve the docs, please feel free to contribute editing the docs in [Docs](https://github.com/quarkiverse/quarkus-openapi-generator/tree/main/docs/modules/ROOT). But first, read [this page](CONTRIBUTING.md).

--- a/client/deployment/pom.xml
+++ b/client/deployment/pom.xml
@@ -8,7 +8,7 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>quarkus-openapi-generator-deployment</artifactId>
-  <name>Quarkus - Openapi Generator - Client - Deployment</name>
+  <name>Quarkus - OpenAPI Generator - Client - Deployment</name>
 
   <properties>
     <version.org.openapitools>7.12.0</version.org.openapitools>

--- a/client/integration-tests/additional-properties/pom.xml
+++ b/client/integration-tests/additional-properties/pom.xml
@@ -8,7 +8,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>quarkus-openapi-generator-it-additional-properties</artifactId>
-  <name>Quarkus - Openapi Generator - Integration Tests - Client - Additional Properties</name>
+  <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Additional Properties</name>
 
   <dependencies>
     <dependency>

--- a/client/integration-tests/array-enum/pom.xml
+++ b/client/integration-tests/array-enum/pom.xml
@@ -8,7 +8,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>quarkus-openapi-generator-it-array-enum</artifactId>
-  <name>Quarkus - Openapi Generator - Integration Tests - Client - Array enum</name>
+  <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Array enum</name>
   <description>Example project for OpenAPI with array of enums</description>
 
   <dependencies>

--- a/client/integration-tests/bean-validation/pom.xml
+++ b/client/integration-tests/bean-validation/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-openapi-generator-it-bean-validation</artifactId>
-    <name>Quarkus - Openapi Generator - Integration Tests - Client - Bean Validation</name>
+    <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Bean Validation</name>
     <description>Example project for usage of the bean-validation property</description>
 
     <dependencies>

--- a/client/integration-tests/beanparam/pom.xml
+++ b/client/integration-tests/beanparam/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-openapi-generator-it-beanparam</artifactId>
-    <name>Quarkus - Openapi Generator - Integration Tests - Client - BeanParam</name>
+    <name>Quarkus - OpenAPI Generator - Integration Tests - Client - BeanParam</name>
     <description>Example project for @BeanParam usage</description>
 
     <dependencies>

--- a/client/integration-tests/change-custom-template-directory/pom.xml
+++ b/client/integration-tests/change-custom-template-directory/pom.xml
@@ -7,7 +7,7 @@
         <version>3.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-openapi-generator-it-change-custom-template-directory</artifactId>
-    <name>Quarkus - Openapi Generator - Integration Tests - Client - Change custom template directory</name>
+    <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Change custom template directory</name>
 
     <dependencies>
         <dependency>

--- a/client/integration-tests/change-directory/pom.xml
+++ b/client/integration-tests/change-directory/pom.xml
@@ -7,7 +7,7 @@
         <version>3.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-openapi-generator-it-change-directory</artifactId>
-    <name>Quarkus - Openapi Generator - Integration Tests - Client - Change directory</name>
+    <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Change directory</name>
 
     <dependencies>
         <dependency>

--- a/client/integration-tests/circuit-breaker/pom.xml
+++ b/client/integration-tests/circuit-breaker/pom.xml
@@ -8,7 +8,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>quarkus-openapi-generator-it-circuit-breaker</artifactId>
-  <name>Quarkus - Openapi Generator - Integration Tests - Client - Circuit Breaker</name>
+  <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Circuit Breaker</name>
 
   <dependencies>
     <dependency>

--- a/client/integration-tests/config-key/pom.xml
+++ b/client/integration-tests/config-key/pom.xml
@@ -8,7 +8,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>quarkus-openapi-generator-it-config-key</artifactId>
-  <name>Quarkus - Openapi Generator - Integration Tests - Client - Config Key</name>
+  <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Config Key</name>
 
   <dependencies>
     <dependency>

--- a/client/integration-tests/cookie-authentication/pom.xml
+++ b/client/integration-tests/cookie-authentication/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-openapi-generator-it-cookie-authentication</artifactId>
-    <name>Quarkus - Openapi Generator - Integration Tests - Client - Cookie Authentication</name>
+    <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Cookie Authentication</name>
     <description>Use cookie authentication</description>
 
     <dependencies>

--- a/client/integration-tests/custom-templates/pom.xml
+++ b/client/integration-tests/custom-templates/pom.xml
@@ -8,7 +8,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>quarkus-openapi-generator-it-custom-templates</artifactId>
-  <name>Quarkus - Openapi Generator - Integration Tests - Client - Custom Templates</name>
+  <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Custom Templates</name>
   <description>Example project with custom templates</description>
 
   <dependencies>

--- a/client/integration-tests/enum-property/pom.xml
+++ b/client/integration-tests/enum-property/pom.xml
@@ -8,7 +8,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>quarkus-openapi-generator-it-enum-property</artifactId>
-  <name>Quarkus - Openapi Generator - Integration Tests - Client - Enum Property</name>
+  <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Enum Property</name>
   <description>Example project for OpenAPI with enum property</description>
 
   <dependencies>

--- a/client/integration-tests/enum-unexpected/pom.xml
+++ b/client/integration-tests/enum-unexpected/pom.xml
@@ -8,7 +8,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>quarkus-openapi-generator-it-enum-unexpected</artifactId>
-  <name>Quarkus - Openapi Generator - Integration Tests - Client - Enum Unexpected</name>
+  <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Enum Unexpected</name>
   <description>Example project for OpenAPI with enum unexpected value</description>
 
   <dependencies>

--- a/client/integration-tests/equals-hashcode/pom.xml
+++ b/client/integration-tests/equals-hashcode/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-openapi-generator-it-equals-hashcode</artifactId>
-    <name>Quarkus - Openapi Generator - Integration Tests - Client - Equals hashcode</name>
+    <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Equals hashcode</name>
     <description>Example project for general usage</description>
 
     <dependencies>

--- a/client/integration-tests/exclude/pom.xml
+++ b/client/integration-tests/exclude/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-openapi-generator-it-exclude</artifactId>
-    <name>Quarkus - Openapi Generator - Integration Tests - Client - Exclude</name>
+    <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Exclude</name>
     <description>Example project with OpenAPI documents that should be excluded</description>
 
     <dependencies>

--- a/client/integration-tests/generate-flags/pom.xml
+++ b/client/integration-tests/generate-flags/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-openapi-generator-it-generate-flags</artifactId>
-    <name>Quarkus - Openapi Generator - Integration Tests - Client - Generate Flags</name>
+    <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Generate Flags</name>
     <description>Example project for usage of the generate-models and generate-apis properties</description>
 
     <dependencies>

--- a/client/integration-tests/generation-input/pom.xml
+++ b/client/integration-tests/generation-input/pom.xml
@@ -7,7 +7,7 @@
     <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>quarkus-openapi-generator-it-generation-input</artifactId>
-  <name>Quarkus - Openapi Generator - Integration Tests - Client - Generation Input</name>
+  <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Generation Input</name>
   <description>Example library that implements the OpenApiSpecInputProvider interface</description>
 
   <dependencies>

--- a/client/integration-tests/generation-tests/pom.xml
+++ b/client/integration-tests/generation-tests/pom.xml
@@ -7,7 +7,7 @@
     <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>quarkus-openapi-generator-it-generation-tests</artifactId>
-  <name>Quarkus - Openapi Generator - Integration Tests - Client - Generation Tests</name>
+  <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Generation Tests</name>
   <description>Example Project that uses the OpenApiSpecProvider (via input Stream) to provide the OpenAPI Spec input. See the module "generation-input", which has this implementation.</description>
   <dependencies>
     <!-- petstore requires OAuth2 -->

--- a/client/integration-tests/github/pom.xml
+++ b/client/integration-tests/github/pom.xml
@@ -8,7 +8,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>quarkus-openapi-generator-it-ghub</artifactId>
-  <name>Quarkus - Openapi Generator - Integration Tests - Client - GitHub spec</name>
+  <name>Quarkus - OpenAPI Generator - Integration Tests - Client - GitHub spec</name>
   <description>Example project for general usage</description>
 
   <dependencies>

--- a/client/integration-tests/include/pom.xml
+++ b/client/integration-tests/include/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-openapi-generator-it-include</artifactId>
-    <name>Quarkus - Openapi Generator - Integration Tests - Client - Include</name>
+    <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Include</name>
     <description>Example project with OpenAPI documents that should be included</description>
 
     <dependencies>

--- a/client/integration-tests/multipart-request/pom.xml
+++ b/client/integration-tests/multipart-request/pom.xml
@@ -8,7 +8,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>quarkus-openapi-generator-it-multipart-request</artifactId>
-  <name>Quarkus - Openapi Generator - Integration Tests - Client - Multipart Request</name>
+  <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Multipart Request</name>
 
   <dependencies>
     <dependency>

--- a/client/integration-tests/mutiny-return-response/pom.xml
+++ b/client/integration-tests/mutiny-return-response/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-openapi-generator-it-mutiny-return-response</artifactId>
-    <name>Quarkus - Openapi Generator - Integration Tests - Client - Mutiny Return Response</name>
+    <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Mutiny Return Response</name>
     <description>Example project for usage of the mutiny-return-response property</description>
 
     <dependencies>

--- a/client/integration-tests/mutiny/pom.xml
+++ b/client/integration-tests/mutiny/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <artifactId>quarkus-openapi-generator-it-mutiny</artifactId>
-    <name>Quarkus - Openapi Generator - Integration Tests - Client - Mutiny</name>
+    <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Mutiny</name>
     <description>Example project for general usage with Mutiny</description>
 
     <dependencies>

--- a/client/integration-tests/open-api-normalizer/pom.xml
+++ b/client/integration-tests/open-api-normalizer/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <artifactId>quarkus-openapi-generator-it-open-api-normalizer</artifactId>
-    <name>Quarkus - Openapi Generator - Integration Tests - Client - OpenAPI Normalizer</name>
+    <name>Quarkus - OpenAPI Generator - Integration Tests - Client - OpenAPI Normalizer</name>
 
     <dependencies>
         <dependency>

--- a/client/integration-tests/part-filename/pom.xml
+++ b/client/integration-tests/part-filename/pom.xml
@@ -8,7 +8,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>quarkus-openapi-generator-it-part-filename</artifactId>
-  <name>Quarkus - Openapi Generator - Integration Tests - Client - PartFilename</name>
+  <name>Quarkus - OpenAPI Generator - Integration Tests - Client - PartFilename</name>
 
   <dependencies>
     <dependency>

--- a/client/integration-tests/path/pom.xml
+++ b/client/integration-tests/path/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <artifactId>quarkus-openapi-generator-it-path</artifactId>
-    <name>Quarkus - Openapi Generator - Integration Tests - Client - path</name>
+    <name>Quarkus - OpenAPI Generator - Integration Tests - Client - path</name>
     <description>Test from path</description>
 
     <dependencies>

--- a/client/integration-tests/polymorphism/pom.xml
+++ b/client/integration-tests/polymorphism/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-openapi-generator-it-polymorphism</artifactId>
-    <name>Quarkus - Openapi Generator - Integration Tests - Client - Polymorphism</name>
+    <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Polymorphism</name>
 
     <dependencies>
         <dependency>

--- a/client/integration-tests/pom.xml
+++ b/client/integration-tests/pom.xml
@@ -8,7 +8,7 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>quarkus-openapi-generator-integration-tests</artifactId>
-  <name>Quarkus - Openapi Generator - Client - Integration Tests</name>
+  <name>Quarkus - OpenAPI Generator - Client - Integration Tests</name>
   <packaging>pom</packaging>
   <modules>
     <module>additional-properties</module>

--- a/client/integration-tests/remove-operationid-prefix/pom.xml
+++ b/client/integration-tests/remove-operationid-prefix/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <artifactId>quarkus-openapi-generator-it-remove-operationid-prefix</artifactId>
-    <name>Quarkus - Openapi Generator - Integration Tests - Client - remove operation id prefix</name>
+    <name>Quarkus - OpenAPI Generator - Integration Tests - Client - remove operation id prefix</name>
     <description>Example project for general usage with remove operation id prefix</description>
 
     <dependencies>

--- a/client/integration-tests/return-response/pom.xml
+++ b/client/integration-tests/return-response/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-openapi-generator-it-return-response</artifactId>
-    <name>Quarkus - Openapi Generator - Integration Tests - Client - return-response</name>
+    <name>Quarkus - OpenAPI Generator - Integration Tests - Client - return-response</name>
     <description>Example project for usage of the return-response property</description>
 
     <dependencies>

--- a/client/integration-tests/security/pom.xml
+++ b/client/integration-tests/security/pom.xml
@@ -8,7 +8,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>quarkus-openapi-generator-it-security</artifactId>
-  <name>Quarkus - Openapi Generator - Integration Tests - Client - Security</name>
+  <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Security</name>
   <description>A few use cases that relies on security use cases with the OpenAPI Generator</description>
 
   <dependencies>

--- a/client/integration-tests/serializable-model/pom.xml
+++ b/client/integration-tests/serializable-model/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-openapi-generator-it-serializable-model</artifactId>
-    <name>Quarkus - Openapi Generator - Integration Tests - Client - Serializable model</name>
+    <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Serializable model</name>
     <description>Example project for general usage</description>
 
     <dependencies>

--- a/client/integration-tests/simple/pom.xml
+++ b/client/integration-tests/simple/pom.xml
@@ -8,7 +8,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>quarkus-openapi-generator-it-simple</artifactId>
-  <name>Quarkus - Openapi Generator - Integration Tests - Client - Simple</name>
+  <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Simple</name>
   <description>Example project for general usage</description>
 
   <dependencies>

--- a/client/integration-tests/skip-validation/pom.xml
+++ b/client/integration-tests/skip-validation/pom.xml
@@ -8,7 +8,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>quarkus-openapi-generator-it-skip-validation</artifactId>
-  <name>Quarkus - Openapi Generator - Integration Tests - Client - Skip Spec Validation</name>
+  <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Skip Spec Validation</name>
   <description>Skip OpenAPI Spec Validation</description>
 
   <dependencies>

--- a/client/integration-tests/suffix-prefix/pom.xml
+++ b/client/integration-tests/suffix-prefix/pom.xml
@@ -8,7 +8,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>quarkus-openapi-generator-it-suffix-prefix</artifactId>
-  <name>Quarkus - Openapi Generator - Integration Tests - Client - Suffix / Prefix</name>
+  <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Suffix / Prefix</name>
 
   <dependencies>
     <dependency>

--- a/client/integration-tests/type-mapping/pom.xml
+++ b/client/integration-tests/type-mapping/pom.xml
@@ -8,7 +8,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>quarkus-openapi-generator-it-type-mapping</artifactId>
-  <name>Quarkus - Openapi Generator - Integration Tests - Client - Type Mapping</name>
+  <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Type Mapping</name>
 
   <dependencies>
     <dependency>

--- a/client/integration-tests/without-oidc/pom.xml
+++ b/client/integration-tests/without-oidc/pom.xml
@@ -8,7 +8,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>quarkus-openapi-generator-it-without-oidc</artifactId>
-  <name>Quarkus - Openapi Generator - Integration Tests - Client - Without OIDC</name>
+  <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Without OIDC</name>
   <description>Example project for general usage</description>
 
   <dependencies>

--- a/client/oidc/pom.xml
+++ b/client/oidc/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <artifactId>quarkus-openapi-generator-oidc</artifactId>
-    <name>Quarkus - Openapi Generator - Client - OIDC</name>
+    <name>Quarkus - OpenAPI Generator - Client - OIDC</name>
     <description>OIDC Capabilities for Runtime</description>
 
     <dependencies>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-openapi-generator-client-parent</artifactId>
-    <name>Quarkus - Openapi Generator - Client - Parent</name>
+    <name>Quarkus - OpenAPI Generator - Client - Parent</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/client/runtime/pom.xml
+++ b/client/runtime/pom.xml
@@ -8,7 +8,7 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>quarkus-openapi-generator</artifactId>
-  <name>Quarkus - Openapi Generator - Client - Runtime</name>
+  <name>Quarkus - OpenAPI Generator - Client - Runtime</name>
   <description>Generation of Rest Clients based on OpenAPI specification files</description>
   <dependencies>
     <!-- Quarkus -->

--- a/client/test-utils/pom.xml
+++ b/client/test-utils/pom.xml
@@ -8,7 +8,7 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>quarkus-openapi-generator-test-utils</artifactId>
-  <name>Quarkus - Openapi Generator - Client - Test Utils</name>
+  <name>Quarkus - OpenAPI Generator - Client - Test Utils</name>
 
   <dependencies>
     <dependency>

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: quarkus-openapi-generator
-title: Openapi Generator
+title: OpenAPI Generator
 version: dev
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -9,7 +9,7 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>quarkus-openapi-generator-docs</artifactId>
-  <name>Quarkus - Openapi Generator - Client - Documentation</name>
+  <name>Quarkus - OpenAPI Generator - Client - Documentation</name>
 
   <dependencies>
     <!-- Make sure the doc is built after the other artifacts -->

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <apicurio.version>1.1.1.Final</apicurio.version>
     <version.com.github.javaparser>3.26.3</version.com.github.javaparser>
     <version.org.assertj>3.27.3</version.org.assertj>
-    <version.org.eclipse.microprofile.fault-tolerance>4.1.1</version.org.eclipse.microprofile.fault-tolerance>
+    <version.org.eclipse.microprofile.fault-tolerance>4.1.2</version.org.eclipse.microprofile.fault-tolerance>
     <version.org.wiremock>3.12.1</version.org.wiremock>
   </properties>
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.19.2</quarkus.version>
+    <quarkus.version>3.19.3</quarkus.version>
     <apicurio.version>1.1.1.Final</apicurio.version>
     <version.com.github.javaparser>3.26.3</version.com.github.javaparser>
     <version.org.assertj>3.27.3</version.org.assertj>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse</groupId>
     <artifactId>quarkiverse-parent</artifactId>
-    <version>18</version>
+    <version>19</version>
   </parent>
   <groupId>io.quarkiverse.openapi.generator</groupId>
   <artifactId>quarkus-openapi-generator-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>quarkus-openapi-generator-parent</artifactId>
   <version>3.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <name>Quarkus - Openapi Generator - Parent</name>
+  <name>Quarkus - OpenAPI Generator - Parent</name>
   <modules>
     <module>client</module>
     <module>server</module>

--- a/server/deployment/pom.xml
+++ b/server/deployment/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-openapi-generator-server-deployment</artifactId>
-    <name>Quarkus - Openapi Generator - Server - Deployment</name>
+    <name>Quarkus - OpenAPI Generator - Server - Deployment</name>
 
     <dependencies>
         <!-- Quarkus -->

--- a/server/integration-tests/pom.xml
+++ b/server/integration-tests/pom.xml
@@ -11,7 +11,7 @@
     <packaging>pom</packaging>
 
     <artifactId>quarkus-openapi-generator-server-integration-tests-parent</artifactId>
-    <name>Quarkus - Openapi Generator - Server - Integration Tests</name>
+    <name>Quarkus - OpenAPI Generator - Server - Integration Tests</name>
 
     <modules>
         <module>reactive</module>

--- a/server/integration-tests/reactive/pom.xml
+++ b/server/integration-tests/reactive/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-openapi-generator-server-integration-tests-quarkus-rest</artifactId>
-    <name>Quarkus - Openapi Generator - Server - Integration Tests - Quarkus REST (formerly RESTEasy Reactive)</name>
+    <name>Quarkus - OpenAPI Generator - Server - Integration Tests - Quarkus REST (formerly RESTEasy Reactive)</name>
 
     <dependencies>
         <dependency>

--- a/server/integration-tests/resteasy/pom.xml
+++ b/server/integration-tests/resteasy/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-openapi-generator-server-integration-tests-resteasy</artifactId>
-    <name>Quarkus - Openapi Generator - Server - Integration Tests - Resteasy</name>
+    <name>Quarkus - OpenAPI Generator - Server - Integration Tests - Resteasy</name>
 
     <dependencies>
         <dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-openapi-generator-server-parent</artifactId>
-    <name>Quarkus - Openapi Generator - Server - Parent</name>
+    <name>Quarkus - OpenAPI Generator - Server - Parent</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/server/runtime/pom.xml
+++ b/server/runtime/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-openapi-generator-server</artifactId>
-    <name>Quarkus - Openapi Generator - Server</name>
+    <name>Quarkus - OpenAPI Generator - Server</name>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [x] Pull Request contains link to the issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
Refactor inputExtension method to inputExtensions
</summary>
The inputExtension method used in package io.quarkiverse.openapi.generator.deployment.codegen  was deprecated since quarkus 3.7.0 in favor of the inputExtensions method. This issue refactor the code for the newer method.
`backport-main-lts`
</details>
